### PR TITLE
Add IAM role module

### DIFF
--- a/iam_role/main.tf
+++ b/iam_role/main.tf
@@ -1,0 +1,37 @@
+variable "name" { type = string }
+variable "policy" { type = string }
+variable "identifier" { type = string }
+
+resource "aws_iam_role" "default" {
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = [var.identifier]
+    }
+  }
+}
+
+resource "aws_iam_policy" "default" {
+  name   = var.name
+  policy = var.policy
+}
+
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = aws_iam_role.default.name
+  policy_arn = aws_iam_policy.default.arn
+}
+
+output "iam_role_arn" {
+  value = aws_iam_role.default.arn
+}
+
+output "iam_role_name" {
+  value = aws_iam_role.default.name
+}


### PR DESCRIPTION
## 概要
IAMロール作成用のmoduleを追加

## 使い方
```hcl
data "aws_iam_policy_document" "allow_describe_regions" {
  statement {
    effect    = "Allow"
    actions   = ["ec2:DescribeRegions"]
    resources = ["*"]
  }
}

module "describe_regions_for_ec2" {
  source     = "./iam_role"
  name       = "${var.project}-${var.environment}-describe-regions-for-ec2"
  identifier = "ec2.amazonaws.com"
  policy     = data.aws_iam_policy_document.allow_describe_regions.json
}
```