### PR TITLE
add nginx on ecs(fargate)

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,7 @@
+# ------------------------------
+# CloudWatch
+# ------------------------------
+resource "aws_cloudwatch_log_group" "for_ecs" {
+  name              = "/dev/nginx/web"
+  retention_in_days = 180
+}

--- a/container_definitions.json
+++ b/container_definitions.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "nginx",
+    "image": "nginx:1.23.3",
+    "essential": true,
+    "portMappings": [
+      {
+        "protocol": "tcp",
+        "containerPort": 80
+      }
+    ]
+  }
+]

--- a/container_definitions.json
+++ b/container_definitions.json
@@ -3,6 +3,14 @@
     "name": "nginx",
     "image": "nginx:1.23.3",
     "essential": true,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "ap-northeast-1",
+        "awslogs-stream-prefix": "nginx",
+        "awslogs-group": "/dev/nginx/web"
+      }
+    },
     "portMappings": [
       {
         "protocol": "tcp",

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,0 +1,54 @@
+# ------------------------------
+# ECS
+# ------------------------------
+resource "aws_ecs_cluster" "example" {
+  name = "${var.project}-${var.environment}-cluster"
+}
+
+resource "aws_ecs_task_definition" "example" {
+  family                   = "${var.project}-${var.environment}-task"
+  cpu                      = "256"
+  memory                   = "512"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  container_definitions    = file("./container_definitions.json")
+}
+
+resource "aws_ecs_service" "example" {
+  name                              = "${var.project}-${var.environment}-service"
+  cluster                           = aws_ecs_cluster.example.arn
+  task_definition                   = aws_ecs_task_definition.example.arn
+  desired_count                     = 2
+  launch_type                       = "FARGATE"
+  platform_version                  = "1.3.0"
+  health_check_grace_period_seconds = 60
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups  = [module.nginx_sg.security_group_id]
+
+    subnets = [
+      aws_subnet.private_1a.id,
+      aws_subnet.private_1c.id,
+    ]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ecs_fargate.arn
+    container_name   = "nginx"
+    container_port   = 80
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}
+
+module "nginx_sg" {
+  source = "./security_group"
+  name   = "${var.environment}-nginx-sg"
+  vpc_id = aws_vpc.example.id
+  ingress_ports = [
+    { port = "80", cidr_blocks = ["0.0.0.0/0"] },
+  ]
+}


### PR DESCRIPTION
# 概要
ecs(fargate)でnginxを実行するように設定する。アクセスログはcloudwatch logsに出力するようにした。

- ✨ feat: add ecs
- ✨ feat: add nginx access log to cloudwatch
